### PR TITLE
Feature/java9+compat

### DIFF
--- a/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
+++ b/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
@@ -88,7 +88,7 @@ public class DependencyManager {
 			method.setAccessible(true);
 			method.invoke(delegatedUrlClassLoader, url);
 		} catch (final Exception ex) {
-			LOGGER.error(MARKER, "Method addURL on delegated classloader could not be invoked", ex);
+			LOGGER.error(MARKER, "Method addURL on transforming / delegated classloader could not be invoked", ex);
 		}
 	}
 }

--- a/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
+++ b/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
@@ -88,7 +88,7 @@ public class DependencyManager {
 			final URLClassLoader delegatedUrlClassLoader = (URLClassLoader) field.get(Thread.currentThread().getContextClassLoader());
 			final Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
 			final Lookup lookup = MethodHandles.lookup();
-			UnsafeHacks.setIntField(Lookup.class.getDeclaredField("allowedModes"), lookup, -1);
+			UnsafeHacks.setIntField(Lookup.class.getDeclaredField("allowedModes"), lookup, -1); // This is a hack to change our lookup to trusted
 			final MethodHandle methodHandle = lookup.unreflectSpecial(method, URLClassLoader.class);
 			methodHandle.invoke(delegatedUrlClassLoader, url);
 			LOGGER.debug(MARKER_ADD, "Added new jar file ({}) to the transforming / delegated classloader.", url);

--- a/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
+++ b/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
@@ -19,12 +19,13 @@ import net.minecraftforge.fml.loading.moddiscovery.ModFile;
 public class DependencyManager {
 	
 	private static final Logger LOGGER = LogManager.getLogger();
-	private static final Marker MARKER = MarkerManager.getMarker("Load");
+	private static final Marker MARKER_LOAD = MarkerManager.getMarker("Load");
+	private static final Marker MARKER_ADD = MarkerManager.getMarker("Add");
 	
 	private static final DependencyClassLoader MUSICPLAYER_CLASSLOADER = new DependencyClassLoader();
 	
 	public static void load() {
-		LOGGER.info(MARKER, "Load dependencies");
+		LOGGER.info(MARKER_LOAD, "Load dependencies");
 		
 		final String devPath = System.getProperty("musicplayer.dev");
 		if (devPath != null) {
@@ -35,7 +36,7 @@ public class DependencyManager {
 			findJarFilesInJar("dependencies/musicplayer", path -> addToMusicPlayerDependencies(createInternalURL(path)));
 		}
 		
-		LOGGER.info(MARKER, "Finished loading dependencies");
+		LOGGER.info(MARKER_LOAD, "Finished loading dependencies");
 	}
 	
 	private static Function<Path, URL> pathToUrl() {
@@ -50,7 +51,7 @@ public class DependencyManager {
 		try (Stream<Path> stream = Files.walk(path)) {
 			stream.filter(file -> file.toString().endsWith(".jar")).forEach(consumer);
 		} catch (final IOException ex) {
-			LOGGER.error(MARKER, "When searching for jar files in dev an exception occured.", ex);
+			LOGGER.error(MARKER_LOAD, "When searching for jar files in dev an exception occured.", ex);
 		}
 	}
 	
@@ -59,17 +60,17 @@ public class DependencyManager {
 		try (Stream<Path> stream = Files.walk(modfile.findResource("/" + folder))) {
 			stream.filter(file -> file.toString().endsWith(".jar")).forEach(consumer);
 		} catch (final IOException ex) {
-			LOGGER.error(MARKER, "When searching for jar files in jar an exception occured.", ex);
+			LOGGER.error(MARKER_LOAD, "When searching for jar files in jar an exception occured.", ex);
 		}
 	}
 	
 	private static URL createInternalURL(Path path) {
 		final String url = "modjar://" + MusicPlayerMod.MODID + path;
-		LOGGER.debug(MARKER, "Load url" + url);
+		LOGGER.debug(MARKER_LOAD, "Load url" + url);
 		try {
 			return new URL(url);
 		} catch (final MalformedURLException ex) {
-			LOGGER.error(MARKER, "Could not create url from internal path", ex);
+			LOGGER.error(MARKER_LOAD, "Could not create url from internal path", ex);
 		}
 		return null;
 	}
@@ -78,6 +79,7 @@ public class DependencyManager {
 	
 	private static void addToMusicPlayerDependencies(URL url) {
 		MUSICPLAYER_CLASSLOADER.addURL(url);
+		LOGGER.debug(MARKER_ADD, "Added new jar file ({}) to the musicplayer dependency classloader.", url);
 	}
 	
 	private static void addToInternalDependencies(URL url) {
@@ -88,8 +90,9 @@ public class DependencyManager {
 			final Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
 			method.setAccessible(true);
 			method.invoke(delegatedUrlClassLoader, url);
+			LOGGER.debug(MARKER_ADD, "Added new jar file ({}) to the transforming / delegated classloader.", url);
 		} catch (final Exception ex) {
-			LOGGER.error(MARKER, "Method addURL on transforming / delegated classloader could not be invoked", ex);
+			LOGGER.error(MARKER_LOAD, "Method addURL on transforming / delegated classloader could not be invoked", ex);
 		}
 	}
 }

--- a/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
+++ b/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
@@ -62,11 +62,11 @@ public class DependencyManager {
 	
 	private static URL createInternalURL(Path path) {
 		final String url = "modjar://" + MusicPlayerMod.MODID + path;
-		LOGGER.debug(MARKER_LOAD, "Load url" + url);
+		LOGGER.debug(MARKER_LOAD, "Create mod jar url ({}) from path ({}).", url, path);
 		try {
 			return new URL(url);
 		} catch (final MalformedURLException ex) {
-			LOGGER.error(MARKER_LOAD, "Could not create url from internal path", ex);
+			LOGGER.error(MARKER_LOAD, "Could not create url from internal path.", ex);
 		}
 		return null;
 	}
@@ -88,7 +88,7 @@ public class DependencyManager {
 			method.invoke(delegatedUrlClassLoader, url);
 			LOGGER.debug(MARKER_ADD, "Added new jar file ({}) to the transforming / delegated classloader.", url);
 		} catch (final Exception ex) {
-			LOGGER.error(MARKER_LOAD, "Method addURL on transforming / delegated classloader could not be invoked", ex);
+			LOGGER.error(MARKER_LOAD, "Method addURL on transforming / delegated classloader could not be invoked.", ex);
 		}
 	}
 }

--- a/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
+++ b/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
@@ -22,7 +22,7 @@ public class DependencyManager {
 	private static final Marker MARKER_LOAD = MarkerManager.getMarker("Load");
 	private static final Marker MARKER_ADD = MarkerManager.getMarker("Add");
 	
-	private static final DependencyClassLoader MUSICPLAYER_CLASSLOADER = new DependencyClassLoader();
+	public static final DependencyClassLoader MUSICPLAYER_CLASSLOADER = new DependencyClassLoader();
 	
 	public static void load() {
 		LOGGER.info(MARKER_LOAD, "Load dependencies");
@@ -41,10 +41,6 @@ public class DependencyManager {
 	
 	private static Function<Path, URL> pathToUrl() {
 		return LamdbaExceptionUtils.rethrowFunction(path -> path.toUri().toURL());
-	}
-	
-	public static DependencyClassLoader getClassLoader() {
-		return MUSICPLAYER_CLASSLOADER;
 	}
 	
 	private static void findJarFilesInDev(Path path, Consumer<Path> consumer) {

--- a/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
+++ b/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
@@ -1,7 +1,7 @@
 package info.u_team.music_player.dependency;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
+import java.lang.reflect.*;
 import java.net.*;
 import java.nio.file.*;
 import java.util.function.Consumer;
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import org.apache.logging.log4j.*;
 
+import cpw.mods.modlauncher.TransformingClassLoader;
 import info.u_team.music_player.MusicPlayerMod;
 import info.u_team.music_player.dependency.classloader.DependencyClassLoader;
 import net.minecraftforge.fml.ModList;
@@ -80,12 +81,14 @@ public class DependencyManager {
 	
 	private static void addToInternalDependencies(URL url) {
 		try {
-			final URLClassLoader systemClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+			final Field field = TransformingClassLoader.class.getDeclaredField("delegatedClassLoader");
+			field.setAccessible(true);
+			final URLClassLoader delegatedUrlClassLoader = (URLClassLoader) field.get(Thread.currentThread().getContextClassLoader());
 			final Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
 			method.setAccessible(true);
-			method.invoke(systemClassLoader, url);
+			method.invoke(delegatedUrlClassLoader, url);
 		} catch (final Exception ex) {
-			LOGGER.error(MARKER, "Method addURL on system classloader could not be invoked", ex);
+			LOGGER.error(MARKER, "Method addURL on delegated classloader could not be invoked", ex);
 		}
 	}
 }

--- a/src/main/java/info/u_team/music_player/dependency/classloader/DependencyClassLoader.java
+++ b/src/main/java/info/u_team/music_player/dependency/classloader/DependencyClassLoader.java
@@ -1,13 +1,8 @@
 package info.u_team.music_player.dependency.classloader;
 
 import java.net.*;
-import java.nio.file.Path;
-
-import org.apache.logging.log4j.*;
 
 public class DependencyClassLoader extends URLClassLoader {
-	
-	private static final Logger LOGGER = LogManager.getLogger();
 	
 	static {
 		ClassLoader.registerAsParallelCapable();
@@ -32,13 +27,5 @@ public class DependencyClassLoader extends URLClassLoader {
 	@Override
 	public void addURL(URL url) {
 		super.addURL(url);
-	}
-	
-	public void addPath(Path path) {
-		try {
-			addURL(path.toUri().toURL());
-		} catch (final MalformedURLException ex) {
-			LOGGER.error("Could not add dependency path to classloader", ex);
-		}
 	}
 }

--- a/src/main/java/info/u_team/music_player/musicplayer/MusicPlayerManager.java
+++ b/src/main/java/info/u_team/music_player/musicplayer/MusicPlayerManager.java
@@ -31,7 +31,7 @@ public class MusicPlayerManager {
 	
 	private static void generatePlayer() {
 		try {
-			final Class<?> clazz = Class.forName("info.u_team.music_player.lavaplayer.MusicPlayer", true, DependencyManager.getClassLoader());
+			final Class<?> clazz = Class.forName("info.u_team.music_player.lavaplayer.MusicPlayer", true, DependencyManager.MUSICPLAYER_CLASSLOADER);
 			if (!IMusicPlayer.class.isAssignableFrom(clazz)) {
 				throw new IllegalAccessError("The class " + clazz + " does not implement IMusicPlayer! This should not happen?!");
 			}


### PR DESCRIPTION
Update dependency manager to not assume that the system class loader is an url classloader. 
Forge uses the transforming class loader to load the minecraft + mod classes which uses an internal delegated classloader that extends the url classloader. 
We assume that it will not change anytime soon so we use reflection to add the additional url path there. 
This should allow musicplayer to load the dependencies in jdk 9+ versions. 

*(We should switch this when forge provides a way to load jar in jar again as this would make it way easier than this classloader hack)*