### PR TITLE
DependencyLoader with ModularURLHandler#initFrom

### DIFF
--- a/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
+++ b/src/main/java/info/u_team/music_player/dependency/DependencyManager.java
@@ -41,7 +41,7 @@ public class DependencyManager {
 	public static void load() {
 		LOGGER.info(MARKER_LOAD, "Load dependencies");
 		
-		setupURLStreamHack();
+		//setupURLStreamHack();
 		
 		final String devPath = System.getProperty("musicplayer.dev");
 		if (devPath != null) {

--- a/src/main/java/info/u_team/music_player/dependency/classloader/DependencyClassLoader.java
+++ b/src/main/java/info/u_team/music_player/dependency/classloader/DependencyClassLoader.java
@@ -1,5 +1,7 @@
 package info.u_team.music_player.dependency.classloader;
 
+import cpw.mods.cl.ModularURLHandler;
+
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -7,6 +9,11 @@ public class DependencyClassLoader extends URLClassLoader {
 	
 	static {
 		ClassLoader.registerAsParallelCapable();
+		/*
+		 Call ServiceLoader.load(ModuleLayer, IURLProvider.class) and put to private Map<String, IURLProvider> handlers
+		 (See resources/META-INF/services/cpw.mods.cl.ModularURLHandler$IURLProvider and cpw.mods.cl.ModularURLHandler#initFrom)
+		 */
+		ModularURLHandler.initFrom(DependencyClassLoader.class.getModule().getLayer());
 	}
 	
 	private final ClassLoader ourClassLoader;

--- a/src/main/java/info/u_team/music_player/dependency/urlprovider/DependencyURLProvider.java
+++ b/src/main/java/info/u_team/music_player/dependency/urlprovider/DependencyURLProvider.java
@@ -1,0 +1,47 @@
+package info.u_team.music_player.dependency.urlprovider;
+
+import cpw.mods.cl.ModularURLHandler;
+import net.minecraftforge.fml.loading.FMLLoader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.function.Function;
+
+/**
+ * Copied method from DependencyManager#setupURLStreamHack and implement IURLProvider.
+ * Loading from ServiceLoader.
+ * (See {@link ModularURLHandler#initFrom(ModuleLayer) ModularURLHander.initFrom(ModuleLayer)},
+ * {@link java.util.ServiceLoader#load(ModuleLayer, Class) ServiceLoader.load(ModuleLayer, Class)},
+ * src/main/resources/META-INF/services/cpw.mods.cl.ModularURLHandler$IURLProvider)
+ */
+public class DependencyURLProvider implements ModularURLHandler.IURLProvider {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    @Override
+    public String protocol() {
+        return "jarlookup";
+    }
+
+    @Override
+    public Function<URL, InputStream> inputStreamFunction() {
+        return url -> {
+            try {
+                final var info = FMLLoader.getLoadingModList().getModFileById(url.getHost());
+                if (info == null) {
+                    throw new IOException("Modid " + url.getHost() + " does not exists");
+                }
+                final var path = info.getFile().findResource(url.getPath().substring(1));
+                return Files.newInputStream(path);
+            } catch (IOException ex) {
+                LOGGER.error("Could not find resource {}", url);
+                throw new UncheckedIOException(ex);
+            }
+        };
+    }
+}

--- a/src/main/resources/META-INF/services/cpw.mods.cl.ModularURLHandler$IURLProvider
+++ b/src/main/resources/META-INF/services/cpw.mods.cl.ModularURLHandler$IURLProvider
@@ -1,0 +1,7 @@
+# When using ServiceLoader, loading file name with package_name.class_name.
+# This means When invoked ServiceLoader.load(ModuleLayer, IURLProvider.class), load file services/cpw.mods.cl.ModularURLHandler$IURLProvider.
+# So should be named to cpw.mods.cl.ModularURLHandler$IURLProvider.
+# (And don't forget the extends or implement classes!)
+
+# Initialize and loading DependencyURLProvider
+info.u_team.music_player.dependency.urlprovider.DependencyURLProvider


### PR DESCRIPTION
(Change DependencyLoader using UnsafeHacks to cpw.mods.cl.ModularURLHandler and IURLProvider, java.util.ServiceLoader)

Just a quick suggestion.
How about using cpw.mods.cl.ModularURLHandler to load the dependencies?
I wrote some code to test it (I commented the original code without deleting it), and it worked for both development and minecraft, so I think it's ok. (I've only tested it with small mods though).
Of course, if you don't need it, feel free to ignore it!
(I used the DeepL translation, but I apologize if the translation is not correct. Also, I apologize if I made a mistake in how to make a pull request)